### PR TITLE
Add Travis CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+`develop` branch -> [![Build Status](https://travis-ci.com/gcivil-nyu-org/fall2019-cs-gy-6063-team-moonsurvivors.svg?token=YtfCuazTkWZrw19nZ9s6&branch=develop)](https://travis-ci.com/gcivil-nyu-org/fall2019-cs-gy-6063-team-moonsurvivors)
 # Team Project repo
 Heroku Production URI: [https://nyu-mercury.herokuapp.com](https://nyu-mercury.herokuapp.com)
 


### PR DESCRIPTION
Update the repo README with the badge for the build status in Travis on the develop branch.