### PR TITLE
Add pre-push local check

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ N.B.: `<something>` means you need to change the `something` text within the ang
 1. Make a feature branch
 `git checkout -b <new_branch_name>`
 2. Make your changes
-3. Use `git add <filename> ...` to add files you changed or more conveniently, `git add -A`.
-4. Commit your changes with `git commit -m "<message_of_what_this_commit_does>"`.
-5. Push your branch to the origin fork with `git push origin <new_branch_name>` of the branch you made locally.
-6. Visit [our repo](https://github.com/gcivil-nyu-org/fall2019-cs-gy-6063-team-moonsurvivors/pulls) to create a Pull Request or use the link that the `git` command printed for you.
-7. Add someone on the team as a review or share your URL to the Slack channel.
+3. Check you are using consistent style by running `scripts/check.sh` and make any recommended changes.
+4. Use `git add <filename> ...` to add files you changed or more conveniently, `git add -A`.
+5. Commit your changes with `git commit -m "<message_of_what_this_commit_does>"`.
+6. Push your branch to the origin fork with `git push origin <new_branch_name>` of the branch you made locally.
+7. Visit [our repo](https://github.com/gcivil-nyu-org/fall2019-cs-gy-6063-team-moonsurvivors/pulls) to create a Pull Request or use the link that the `git` command printed for you.
+8. Add someone on the team as a review or share your URL to the Slack channel.
 
 # HOWTO Run the app locally
 Run `python manage.py runserver` from the root of this Git repo

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cd "$(git rev-parse --show-toplevel)"
+black --check mysite mercury
+flake8 mysite mercury


### PR DESCRIPTION
This `check.sh` can be run locally to ensure your build doesn't fail because of style rules being violated as detected by `black` and `flake8`. You can make a git hook to run it automatically if you wish, or just remember to run this before you push your branch to origin.