### PR TITLE
Add auto-refresh and descending sort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 env/
 
 .vscode/
+staticfiles/

--- a/mercury/templates/dashboard-live.html
+++ b/mercury/templates/dashboard-live.html
@@ -7,6 +7,8 @@
 <body>
 <h1>Dashboard</h1>
 <h3>The Simulated Data for each data packet sent is shown:</h3>
+{%  load static %}
+<script src="{%  static "/mercury/js/jquery-3.4.1.js" %}"></script>
 <div>
     <table id="main_dash" style="border: 1px solid black">
         The simulated data for each data package is shown below:<br><br>

--- a/mercury/templates/dashboard-live.html
+++ b/mercury/templates/dashboard-live.html
@@ -8,7 +8,7 @@
 <h1>Dashboard</h1>
 <h3>The Simulated Data for each data packet sent is shown:</h3>
 {%  load static %}
-<script src="{%  static "/mercury/js/jquery-3.4.1.js" %}"></script>
+<script src="{%  static "mercury/js/jquery-3.4.1.js" %}"></script>
 <div>
     <table id="main_dash" style="border: 1px solid black">
         The simulated data for each data package is shown below:<br><br>

--- a/mercury/templates/dashboard.html
+++ b/mercury/templates/dashboard.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8"  http-equiv="refresh" content="5; URL=/dashboard/"/>
     <title>Dashboard</title>
 </head>
 <body>

--- a/mercury/test_views.py
+++ b/mercury/test_views.py
@@ -1,0 +1,20 @@
+from django.test import TestCase, Client
+from django.urls import reverse
+
+
+class TestViews(TestCase):
+
+    def test_dashboard(self):
+        client = Client()
+        response = client.get(reverse('mercury:dashboard'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_dashboard_live(self):
+        client = Client()
+        response = client.get(reverse('mercury:dashboard-live'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_simulator(self):
+        client = Client()
+        response = client.get(reverse('mercury:simulator'))
+        self.assertEqual(response.status_code, 200)

--- a/mercury/test_views.py
+++ b/mercury/test_views.py
@@ -3,18 +3,17 @@ from django.urls import reverse
 
 
 class TestViews(TestCase):
-
     def test_dashboard(self):
         client = Client()
-        response = client.get(reverse('mercury:dashboard'))
+        response = client.get(reverse("mercury:dashboard"))
         self.assertEqual(response.status_code, 200)
 
     def test_dashboard_live(self):
         client = Client()
-        response = client.get(reverse('mercury:dashboard-live'))
+        response = client.get(reverse("mercury:dashboard-live"))
         self.assertEqual(response.status_code, 200)
 
     def test_simulator(self):
         client = Client()
-        response = client.get(reverse('mercury:simulator'))
+        response = client.get(reverse("mercury:simulator"))
         self.assertEqual(response.status_code, 200)

--- a/mercury/test_views.py
+++ b/mercury/test_views.py
@@ -17,3 +17,8 @@ class TestViews(TestCase):
         client = Client()
         response = client.get(reverse("mercury:simulator"))
         self.assertEqual(response.status_code, 200)
+
+    def test_index(self):
+        client = Client()
+        response = client.get(reverse("mercury:index"))
+        self.assertEqual(response.status_code, 200)

--- a/mercury/urls.py
+++ b/mercury/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path("about/", views.AboutPageView.as_view(), name="about"),
     path("simulator/", simulator.SimulatorView.as_view(), name="simulator"),
     path("dashboard/", dashboard.DashboardView.as_view(), name="dashboard"),
+    path("dashboard-live/", dashboard.DashboardLiveView.as_view(), name="dashboard-live")
 ]

--- a/mercury/urls.py
+++ b/mercury/urls.py
@@ -7,5 +7,7 @@ urlpatterns = [
     path("about/", views.AboutPageView.as_view(), name="about"),
     path("simulator/", simulator.SimulatorView.as_view(), name="simulator"),
     path("dashboard/", dashboard.DashboardView.as_view(), name="dashboard"),
-    path("dashboard-live/", dashboard.DashboardLiveView.as_view(), name="dashboard-live")
+    path(
+        "dashboard-live/", dashboard.DashboardLiveView.as_view(), name="dashboard-live"
+    ),
 ]

--- a/mercury/views/dashboard.py
+++ b/mercury/views/dashboard.py
@@ -10,3 +10,11 @@ class DashboardView(TemplateView):
     def get(self, request, *args, **kwargs):
         all_data = SimulatedData.objects.all()
         return render(request, self.template_name, {"all_data": all_data})
+
+
+class DashboardLiveView(TemplateView):
+    template_name = "dashboard-live.html"
+
+    def get(self, request, *args, **kwargs):
+        all_data = SimulatedData.objects.all()
+        return render(request, self.template_name, {"all_data": all_data})

--- a/mercury/views/dashboard.py
+++ b/mercury/views/dashboard.py
@@ -8,7 +8,7 @@ class DashboardView(TemplateView):
     template_name = "dashboard.html"
 
     def get(self, request, *args, **kwargs):
-        all_data = SimulatedData.objects.all()
+        all_data = SimulatedData.objects.all().order_by("-created_at")
         return render(request, self.template_name, {"all_data": all_data})
 
 


### PR DESCRIPTION
This change adds a 5-second refresh to the `dashboard/` endpoint and sorts the results with the newest at the top, so it should keep on pushing the list down as data gets made. 

This change also adds a new `dashboard-live/` endpoint which I am using to test ajax things in, and will ultimately store the code for the single-page dashboard. Once it works, we can switch over easily, so I am keeping the primary `dashboard/` endpoint pointed at the existing view.

I also add a `test_views.py` to add test coverage for Views.