### PR TITLE
Remove code we won't be using

### DIFF
--- a/mercury/test_views.py
+++ b/mercury/test_views.py
@@ -10,11 +10,6 @@ class TestViews(TestCase):
         response = client.get(reverse("mercury:dashboard"))
         self.assertEqual(response.status_code, 200)
 
-    def test_dashboard_live(self):
-        client = Client()
-        response = client.get(reverse("mercury:dashboard-live"))
-        self.assertEqual(response.status_code, 200)
-
     def test_simulator(self):
         client = Client()
         response = client.get(reverse("mercury:simulator"))

--- a/mercury/urls.py
+++ b/mercury/urls.py
@@ -7,8 +7,4 @@ urlpatterns = [
     path("about/", views.AboutPageView.as_view(), name="about"),
     path("simulator/", simulator.SimulatorView.as_view(), name="simulator"),
     path("dashboard/", dashboard.DashboardView.as_view(), name="dashboard"),
-    path(
-        "dashboard-live/", dashboard.DashboardLiveView.as_view(), name="dashboard-live"
-    ),
-    path("api/chart/data/", dashboard.ChartData.as_view(), name="api-chart-data"),
 ]

--- a/mercury/views/dashboard.py
+++ b/mercury/views/dashboard.py
@@ -1,11 +1,6 @@
 from django.shortcuts import render
 from django.views.generic import TemplateView
-from django.http import HttpResponseRedirect  # noqa
 from ..models import SimulatedData
-
-# adding the Rest API
-from rest_framework.response import Response
-from rest_framework.views import APIView
 
 
 class DashboardView(TemplateView):
@@ -15,29 +10,3 @@ class DashboardView(TemplateView):
         all_data = SimulatedData.objects.all().order_by("-created_at")
         return render(request, self.template_name, {"all_data": all_data})
 
-
-class DashboardLiveView(TemplateView):
-    template_name = "dashboard-live.html"
-
-    def get(self, request, *args, **kwargs):
-        all_data = SimulatedData.objects.all()
-        return render(request, self.template_name, {"all_data": all_data})
-
-
-class ChartData(APIView):
-    authentication_classes = []
-    permission_classes = []
-
-    def get(self, request, format=None):
-        dictionary = dict()
-        for item in SimulatedData.objects.all().order_by("-created_at"):
-            dictionary[item.created_at] = item.temperature
-
-        # dictionary = sorted(dictionary.items(), key=lambda x: x[0])
-        # dictionary = dict(dictionary)
-
-        data = {
-            "article_labels": dictionary.keys(),
-            "article_data": dictionary.values(),
-        }
-        return Response(data)

--- a/mercury/views/dashboard.py
+++ b/mercury/views/dashboard.py
@@ -9,4 +9,3 @@ class DashboardView(TemplateView):
     def get(self, request, *args, **kwargs):
         all_data = SimulatedData.objects.all().order_by("-created_at")
         return render(request, self.template_name, {"all_data": all_data})
-

--- a/mercury/views/views.py
+++ b/mercury/views/views.py
@@ -1,6 +1,5 @@
 from django.shortcuts import render
 from django.views.generic import TemplateView
-from django.http import HttpResponseRedirect  # noqa
 
 
 class HomePageView(TemplateView):

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -44,7 +44,6 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "crispy_forms",
     "mercury.apps.MercuryConfig",
-    "rest_framework",
 ]
 
 MIDDLEWARE = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ django-heroku==0.3.*
 django-crispy-forms==1.8.*
 django-tastypie==0.14.*
 python-dotenv==0.10.*
-djangorestframework==3.10.*


### PR DESCRIPTION
Since we won't be using Plotly, we should remove the related components from out codebase. This also removes the 'dashboard-live' which I setup for testing but didn't need. We can always re-add these if we need to.