### PR TITLE
Remove accidental space

### DIFF
--- a/mercury/templates/simulator.html
+++ b/mercury/templates/simulator.html
@@ -6,8 +6,8 @@
 <head>
     <meta charset="UTF-8">
     <title>Simulator</title>
-    <script src="{% static " mercury/js/jquery-3.4.1.js " %}"></script>
-    <script src="{% static " mercury/js/simulator.js " %}"></script>
+    <script src="{% static "mercury/js/jquery-3.4.1.js" %}"></script>
+    <script src="{% static "mercury/js/simulator.js" %}"></script>
     <script>
         function RedirectSimulator() {
             window.location = "/";


### PR DESCRIPTION
I accidentally added spaces in Muneeb's commit #201 to the URL, causing them to 404 when simulator.html loaded. This fixes it.